### PR TITLE
Small bugfix

### DIFF
--- a/data_loading/learning_objectives.py
+++ b/data_loading/learning_objectives.py
@@ -378,7 +378,7 @@ class LabelPredictionLearningObjective(LearningObjective):
         label_predictions = predictions[ModelOutputNames.LABEL_PREDICTIONS]
         labels = outputs[ModelInputNames.FINETUNE_LABEL]
 
-        loss = self._criterion(torch.squeeze(label_predictions), labels.float())
+        loss = self._criterion(torch.squeeze(label_predictions), labels.float().squeeze())
         self._performance.add(loss=loss.float().mean().item(),
                               prediction=label_predictions.detach().cpu().tolist(),
                               label=labels.detach().cpu().tolist())

--- a/training/train_model.py
+++ b/training/train_model.py
@@ -277,7 +277,7 @@ class ModelTrainer:
         self._writer = SummaryWriter(self._settings.output_folder)
         self._load_checkpoint()
         start = self._epoch + 1
-        if (self._settings.training_settings.num_freeze_epochs >= self._epoch and
+        if (self._settings.training_settings.num_freeze_epochs >= (self._epoch + 1) and
                 self._settings.pretrained_model_folder is not None):
             logging.info("Freezing pre-trained model weights")
             self._model.freeze_non_head()

--- a/training/train_model.py
+++ b/training/train_model.py
@@ -267,7 +267,8 @@ class ModelTrainer:
             new_json_file = os.path.join(self._settings.output_folder, CONCEPT_TOKENIZER_FILE_NAME)
             self._concept_tokenizer.save_to_json(new_json_file)
             if (self._settings.learning_objective_settings.masked_visit_concept_learning or
-                    self._settings.learning_objective_settings.label_prediction):
+                    self._settings.learning_objective_settings.label_prediction or
+                    self._settings.learning_objective_settings.lstm_label_prediction):
                 new_json_file = os.path.join(self._settings.output_folder, VISIT_CONCEPT_TOKENIZER_FILE_NAME)
                 self._visit_concept_tokenizer.save_to_json(new_json_file)
 


### PR DESCRIPTION
@schuemie this is a small PR with some small bugs I found in Apollo.

- If the batch size is one, it would break
- Visit concept tokenizer wasn't copied correctly over if task was ```lstm_label_prediction```
- When disabling freezing by setting freezing epoch to zero, it would still freeze the first epoch.

